### PR TITLE
Revised CSS to Fix Icon Location at Start of Game

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,6 @@ body {
 
 #bigFoot {
   position: absolute;
-  left: 125px;
-  top: 200px;
+  left: 250px;
+  top: 100px;
 }


### PR DESCRIPTION
As game begins, icon has tendency to appear in high contrast space of forest.jpg. Modified CSS values for icon to obscure by default.